### PR TITLE
Feature/score optimization

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,3 +35,4 @@ SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 UseTab: Never
 IndentCaseLabels: true
+AlwaysBreakAfterDefinitionReturnType: All

--- a/examples/ESP32_AMOS_MONSTER/ESP32_AMOS_MONSTER.ino
+++ b/examples/ESP32_AMOS_MONSTER/ESP32_AMOS_MONSTER.ino
@@ -10,7 +10,7 @@ int button_honba = 18;
 // If you only use 3 score stick bins per player, write the 3th value as 1000.0f.
 float RES_AMOS_MONSTER[] = {
   // in kiloohms
-  20.0f, 100.0f, 1000.0f, 1000.0f};
+  20.0f, 100.0f, 200.0f, 1000.0f};
 
 #if REF_CORRECTION_DIMENTION == 1
 // in kiloohms

--- a/examples/ESP32_AMOS_MONSTER/ESP32_AMOS_MONSTER.ino
+++ b/examples/ESP32_AMOS_MONSTER/ESP32_AMOS_MONSTER.ino
@@ -6,12 +6,22 @@ int button_mode[] = {
   // if you don't want to, use other pins
 };
 int button_honba = 18;
+
+// If you only use 3 score stick bins per player, write the 3th value as 1000.0f.
 float RES_AMOS_MONSTER[] = {
   // in kiloohms
   20.0f, 100.0f, 1000.0f, 1000.0f};
-float R_REF[] = {
-  // in kiloohms
-  10.0f, 10.0f, 10.0f, 10.0f};
+
+#if REF_CORRECTION_DIMENTION == 1
+// in kiloohms
+float R_REF[] = {10.0f, 10.0f, 10.0f, 10.0f};
+#elif REF_CORRECTION_DIMENTION == 2
+// If you only use 3 score stick bins per player, write the 4th value as 0.
+// {{9.90f, 9.95f, 98.9f, 0}, {9.94f, 9.94f, 98.1f, 0}, {10.00f, 9.96f, 98.3f, 0}, {9.86f, 9.95f, 98.8f, 0}};
+// Fill in the actual resistance values in order from player #1's score stick bin #1 to player #4's score stick bin #4.
+// in kiloohms
+float R_REF[4][4] = {{9.90f, 9.95f, 98.9f, 98.9f}, {9.94f, 9.94f, 98.1f, 101.2f}, {10.00f, 9.96f, 98.3f, 101.1f}, {9.86f, 9.95f, 98.8f, 98.0f}};
+#endif
 
 ADS1115 ADC0(0x48, &Wire);
 ADS1115 ADC1(0x49, &Wire);
@@ -47,7 +57,16 @@ U8X8_SSD1306_128X64_NONAME_2ND_HW_I2C oled3(U8X8_PIN_NONE);
 U8X8 oled[] = {oled0, oled1, oled2, oled3};
 
 int i2c_address[4] = {0x78, 0x7A, 0x78, 0x7A};
+#if REF_CORRECTION_DIMENTION == 1
+// in kiloohms
 float weight[] = {0.3f, 0.3f, 0.3f, 0.3f};
+#elif REF_CORRECTION_DIMENTION == 2
+// If you only use 3 score stick bins per player, write the 4th value as 0.
+// {{0.3f, 0.3f, 0.55f, 0}, {0.3f, 0.3f, 0.55f, 0}, {0.3f, 0.3f, 0.6f, 0}, {0.3f, 0.3f, 0.6f, 0}};
+// Fill in the actual resistance values in order from player #1's score stick bin #1 to player #4's score stick bin #4.
+// in kiloohms
+float weight[4][4] = {{0.3f, 0.3f, 0.55f, 0.5f}, {0.3f, 0.3f, 0.55f, 0.57f}, {0.3f, 0.3f, 0.6f, 0.6f}, {0.3f, 0.3f, 0.6f, 0.43f}};
+#endif
 enum I2CPIN
 {
   _SDA0 = 19,

--- a/src/EiMOS_U8X8.cpp
+++ b/src/EiMOS_U8X8.cpp
@@ -102,6 +102,11 @@ EiMOS_U8X8::EiMOS_U8X8(ADS1X15 *ext_adc[], float v_unit[], float ref[])
 {
 }
 
+EiMOS_U8X8::EiMOS_U8X8(ADS1X15 *ext_adc[], float v_unit[], float ref[][4])
+    : EiMOS(ext_adc, v_unit, ref)
+{
+}
+
 void
 EiMOS_U8X8::setDisplay(U8X8 *u8x8[])
 {

--- a/src/EiMOS_U8X8.h
+++ b/src/EiMOS_U8X8.h
@@ -74,6 +74,7 @@ class EiMOS_U8X8 : public EiMOS
   EiMOS_U8X8(int analog, float v_unit[], float ref[]);
   EiMOS_U8X8(int charge[], ADS1X15 *ext_adc[], float v_unit[], float ref[]);
   EiMOS_U8X8(ADS1X15 *ext_adc[], float v_unit[], float ref[]);
+  EiMOS_U8X8(ADS1X15 *ext_adc[], float v_unit[], float ref[][4]);
   U8X8 **getU8X8();
   void setNullU8X8();
   void setDisplay(U8X8 *u8x8[]);


### PR DESCRIPTION
## Task Summary 🤩

- EiMOS의 RES 모드에서의 점수 측정 정확성 증대

<br>

## Changes 🗝️

### main.cpp
- R_REF[]
  + 1차원, 2차원 배열 모두 사용 가능하도록 메소드 오버로딩
  + 2차원 배열로 사용할 경우, 기준저항값을 이상치가 아닌 실측값으로 작성

- weight[]
  + 2차원 배열로 사용할 경우, 기준저항값을 이상치가 아닌 실측값으로 작성

위의 모든 배열 차원 설정은 `EiMOS.h` 파일의 `REF_CORRECTION_DIMENTION` 의 값에 따라 전처리기로 정의됨

- RES_AMOS_MONSTER[]
  + 500점봉칸 100점봉칸을 분리하여 이에따른 점봉 저항값 분리
    - 500점봉칸과 100점봉칸을 분리하지 않고 사용할 경우 `200.0f`를 `1000.0f`로 수정

<br>

## To Reviewers 📢

<br>

## Self Checklist

-   [x] 적절한 라벨을 추가했습니다. (feat, fix, chore, etc..)
-   [x] 셀프 코드리뷰를 진행했습니다.
-   [ ] 리뷰어가 이해하기 어려운 영역에 대한 설명을 작성했습니다. (필요시)
-   [ ] 중점적으로 살펴보았으면 하는 영역에 대한 설명을 작성했습니다. (필요시)

